### PR TITLE
g3_fit: Look for parameter names in correct place

### DIFF
--- a/R/g3_fit.R
+++ b/R/g3_fit.R
@@ -35,7 +35,7 @@ g3_fit <- function(model,
           tmp <- NULL
       }
   } else if (inherits(model, "g3_cpp")) {
-      if (is.data.frame(params) && "report_detail" %in% names(params$switch) && printatstart == 1) {
+      if (is.data.frame(params) && "report_detail" %in% params$switch && printatstart == 1) {
           params['report_detail', 'value'] <- 1L
           tmp <- gadget3::g3_tmb_adfun(model, params)$report(gadget3::g3_tmb_par(params))
       } else {


### PR DESCRIPTION
params$switch is the vector containing the names, names(params$switch) is empty so will never succeed.