### PR TITLE
Improve g3_iterative error message

### DIFF
--- a/R/g3_iterative.R
+++ b/R/g3_iterative.R
@@ -388,7 +388,9 @@ g3_iterative_setup <- function(lik_out,
   }
   
   if (!all(unlist(grouping) %in% gsub('^.dist_(surveyindices_log|[a-z]+)_', '', lik_out$comp))){
-    stop('The specified grouping do not all match component names')
+    stop(paste(setdiff(unlist(grouping), gsub('^.dist_(surveyindices_log|[a-z]+)_', '', lik_out$comp)), collapse = ", "), 
+         " grouping names do not all match weight component names", 
+         ifelse(any(grepl("^log_", unlist(grouping))), ". There is log_ in front of a survey index. This should not be supplied any longer.", ""))
   }
   
   ## Setup groups for re-weighting (i.e. components to be optimised together)


### PR DESCRIPTION
Earlier "log_" was required in front of survey indices when specifying the grouping argument list. This commit removed the requirement and threw an error instead: https://github.com/gadget-framework/gadgetutils/commit/1a3229329874681baa3d619f8d0a57929e43380a

This error message was not very clear and caused confusion. I improved the message by printing the weight component names that did not match the gsub hoping to make the user understand where the error comes from.