### PR TITLE
g3_fit: Find step_lengths more flexibly #131

### DIFF
--- a/R/g3_fit.R
+++ b/R/g3_fit.R
@@ -82,7 +82,12 @@ g3_fit <- function(model,
   
   
   ## Calculate the step size as a proportion
-  step_size <- 1/length(environment(gadget3:::g3_collate(attr(model, 'actions'))$`000`)$step_lengths)
+  step_lengths <- tmp$step_lengths
+  if (is.null(step_lengths)) {
+      model_f <- gadget3:::f_concatenate(gadget3:::g3_collate(attr(model, 'actions')))
+      step_lengths <- get('step_lengths', envir = environment(model_f), inherits = TRUE)
+  }
+  step_size <- 1/length(step_lengths)
 
   ##############################################################################
   ##############################################################################


### PR DESCRIPTION
Firstly, if it's in the report use that.

If that fails, then collate all the actions together and find it in the resulting environment. This means we don't have to hard code a step ID, which is going to change in the near future.

Maybe gadget3 should offer a g3_to_formula() to do this, it's a oft' repeated chunk of code internally.

References: https://github.com/gadget-framework/gadget3/issues/131