### PR TITLE
g3_fit: Use attr(..., 'model_data') to get R-named data

### DIFF
--- a/R/g3_fit.R
+++ b/R/g3_fit.R
@@ -37,7 +37,7 @@ g3_fit <- function(model,
           params['report_detail', 'value'] <- 1L
           obj_fun <- gadget3::g3_tmb_adfun(model, params, type = 'Fun')
           tmp <- obj_fun$report(gadget3::g3_tmb_par(params))
-          data_env <- as.environment(obj_fun$env$data)
+          data_env <- as.environment(attr(model, 'model_data'))
       } else {
           tmp <- NULL
       }


### PR DESCRIPTION
obj_fun$env$data has already been mangled into C++ naming, which is an irreversible process. The report data will fix the mangling, so names won't line up ("." vs "__").

Instead, get the data from the model object, before it is mangled.

Fixes https://github.com/gadget-framework/gadgetutils/commit/64f94d1833d0fdf591ab2bcdc0420d44a67e1b30#commitcomment-150500219