### PR TITLE
g3_fit: Split up model-running and fit generation

### DIFF
--- a/R/g3_fit.R
+++ b/R/g3_fit.R
@@ -19,10 +19,6 @@ g3_fit <- function(model,
     stop("The printatstart argument must be '0' or '1' (class numeric)")
   }
   
-  ## Returning parameters as they are put in for now
-  ## so model(fit$params) will work without any fiddling
-  out_params <- params
-  
   if (inherits(model, "g3_r")) {
     if (is.data.frame(params)) params <- params$value
       if ("report_detail" %in% names(params) && printatstart == 1) {
@@ -78,12 +74,31 @@ g3_fit <- function(model,
     tmp <- attributes(model(params))
     data_env <- environment(model)
   }
-  
-  
+
+  ## Add run information back to reporting output, if not already there
+  if (is.null(tmp$model_params)) tmp$model_params <- params
+  if (is.null(tmp$model_data)) tmp$model_data <- data_env
+
+  return(g3_fit_inner(tmp, rec.steps = rec.steps, steps = steps))
+}
+
+# Generate fit report from reporting output of g3_fit()
+g3_fit_inner <- function(tmp,
+                         rec.steps = 1,
+                         steps = 1) {
+  data_env <- tmp$model_data
+
+  ## Returning parameters as they are put in for now
+  ## so model(fit$params) will work without any fiddling
+  params <- tmp$model_params
+  out_params <- params
   
   ## Calculate the step size as a proportion
   step_lengths <- tmp$step_lengths
   step_size <- 1/length(step_lengths)
+
+  # If dend_ or endprint_ are available, then printatstart was 0
+  printatstart <- if (any(grepl("^(dend|endprint)_(.+)__wgt$", names(tmp)))) 0 else 1
 
   # Work out abundance naming
   if(any(grepl("^dstart_(.+)__wgt$", names(tmp)))) {

--- a/R/g3_fit.R
+++ b/R/g3_fit.R
@@ -83,10 +83,6 @@ g3_fit <- function(model,
   
   ## Calculate the step size as a proportion
   step_lengths <- tmp$step_lengths
-  if (is.null(step_lengths)) {
-      model_f <- gadget3:::f_concatenate(gadget3:::g3_collate(attr(model, 'actions')))
-      step_lengths <- get('step_lengths', envir = environment(model_f), inherits = TRUE)
-  }
   step_size <- 1/length(step_lengths)
 
   # Work out abundance naming


### PR DESCRIPTION
This splits off the model-running from the report generation in g3_fit(). This shouldn't really alter anything immediately, I mostly wanted to know if it was possible.

Given it seems to be, then it'd be worth keeping so it stays that way. This means we can do things like:

1. Add tests with saved report output, feed that into g3_fit, and compare the output. We don't have to have an associated model to run a test. We can then use that to break up ``g3_fit_inner()`` into smaller chunks to ensure nothing gets broken.
2. Run lots of projections, with the possibility of still using ``g3_fit()`` on the output afterwards. Ultimately being able to choose the output you want by invoking bits of ``g3_fit()``.
